### PR TITLE
Update JSON endpoint path in `Serialization` and corresponding test

### DIFF
--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/Serialization.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/Serialization.kt
@@ -13,7 +13,7 @@ fun Application.configureSerialization() {
         json()
     }
     routing {
-        get("/json/kotlinx-serialization-test") {
+        get("/json/kotlinx-serialization-teste") {
             call.respond(mapOf("hello" to "world"))
         }
     }

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/Serialization.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/Serialization.kt
@@ -13,7 +13,7 @@ fun Application.configureSerialization() {
         json()
     }
     routing {
-        get("/json/kotlinx-serialization") {
+        get("/json/kotlinx-serialization-test") {
             call.respond(mapOf("hello" to "world"))
         }
     }

--- a/src/test/kotlin/dev/kotlinbr/ApplicationModuleTest.kt
+++ b/src/test/kotlin/dev/kotlinbr/ApplicationModuleTest.kt
@@ -56,7 +56,7 @@ class ApplicationModuleTest {
             assertEquals("Hello World!", root.bodyAsText())
 
             // JSON sample endpoint installed by Serialization.kt
-            val json = client.get("/json/kotlinx-serialization-test")
+            val json = client.get("/json/kotlinx-serialization-teste")
             assertEquals(HttpStatusCode.OK, json.status)
             assertEquals("{\"hello\":\"world\"}", json.bodyAsText())
 

--- a/src/test/kotlin/dev/kotlinbr/ApplicationModuleTest.kt
+++ b/src/test/kotlin/dev/kotlinbr/ApplicationModuleTest.kt
@@ -56,7 +56,7 @@ class ApplicationModuleTest {
             assertEquals("Hello World!", root.bodyAsText())
 
             // JSON sample endpoint installed by Serialization.kt
-            val json = client.get("/json/kotlinx-serialization")
+            val json = client.get("/json/kotlinx-serialization-test")
             assertEquals(HttpStatusCode.OK, json.status)
             assertEquals("{\"hello\":\"world\"}", json.bodyAsText())
 


### PR DESCRIPTION
Troca do nome da rota de serialização JSON.

Closes #1.