### PR TITLE
Implementa o endpoint `POST /api/v1/shorten`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,8 @@ dependencies {
 
     // --- Test dependencies ---
     testImplementation("io.ktor:ktor-server-test-host")
+    testImplementation("io.ktor:ktor-client-content-negotiation")
+    testImplementation("io.ktor:ktor-serialization-kotlinx-json")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.3")

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
@@ -1,12 +1,16 @@
 package dev.kotlinbr.utlshortener.interfaces.http
 
+import dev.kotlinbr.utlshortener.app.services.SlugGenerator
+import dev.kotlinbr.utlshortener.domain.Link
 import dev.kotlinbr.utlshortener.infrastructure.repository.LinksRepository
+import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenRequest
+import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenResponse
 import dev.kotlinbr.utlshortener.interfaces.http.dto.toResponse
-import io.ktor.server.application.Application
-import io.ktor.server.response.respond
-import io.ktor.server.routing.get
-import io.ktor.server.routing.route
-import io.ktor.server.routing.routing
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import java.time.OffsetDateTime
 
 /**
  * API endpoints.
@@ -18,6 +22,25 @@ fun Application.configureApiRoutes() {
                 val links = LinksRepository().findAll()
                 val response = links.map { it.toResponse() }
                 call.respond(response)
+            }
+
+            post("/shorten") {
+                val shortenCreate = call.receive<ShortenRequest>()
+                val linksRepository = LinksRepository()
+                val slugGenerator = SlugGenerator(linksRepository)
+                val slug = slugGenerator.generate()
+                val link =
+                    Link(
+                        id = null,
+                        slug = slug,
+                        targetUrl = shortenCreate.url,
+                        createdAt = OffsetDateTime.now(),
+                        isActive = true,
+                        expiresAt = null,
+                    )
+                linksRepository.save(link)
+                val resposes = ShortenResponse(slug, "/$slug")
+                call.respond(resposes)
             }
         }
     }

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
@@ -6,8 +6,8 @@ import dev.kotlinbr.utlshortener.infrastructure.repository.LinksRepository
 import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenRequest
 import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenResponse
 import dev.kotlinbr.utlshortener.interfaces.http.dto.toResponse
-import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
+import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
@@ -28,20 +28,19 @@ fun Application.configureApiRoutes() {
             }
             post("/shorten") {
                 val shortenCreate = call.receive<ShortenRequest>()
-                val linksRepository = LinksRepository()
-                val slugGenerator = SlugGenerator(linksRepository)
-                val slug = slugGenerator.generate()
                 val url = shortenCreate.url.trim()
 
                 if (url.isEmpty()) {
-                    call.respond(HttpStatusCode.BadRequest, "URL não pode estar vazia.")
-                    return@post
+                    throw BadRequestException("URL não pode estar vazia.")
                 }
 
                 if (!url.startsWith("http://") && !url.startsWith("https://")) {
-                    call.respond(HttpStatusCode.BadRequest, "URL inválida. Use http:// ou https://")
-                    return@post
+                    throw BadRequestException("URL inválida. Use http:// ou https://")
                 }
+
+                val linksRepository = LinksRepository()
+                val slugGenerator = SlugGenerator(linksRepository)
+                val slug = slugGenerator.generate()
 
                 val link =
                     Link(

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
@@ -14,7 +14,6 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
-import java.time.OffsetDateTime
 
 /**
  * API endpoints.
@@ -46,12 +45,8 @@ fun Application.configureApiRoutes() {
 
                 val link =
                     Link(
-                        id = null,
                         slug = slug,
                         targetUrl = url,
-                        createdAt = OffsetDateTime.now(),
-                        isActive = true,
-                        expiresAt = null,
                     )
 
                 linksRepository.save(link)

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/ApiRoutes.kt
@@ -7,10 +7,13 @@ import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenRequest
 import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenResponse
 import dev.kotlinbr.utlshortener.interfaces.http.dto.toResponse
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.*
-import io.ktor.server.request.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
+import io.ktor.server.application.Application
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
 import java.time.OffsetDateTime
 
 /**

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/Routing.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/Routing.kt
@@ -3,11 +3,16 @@ package dev.kotlinbr.utlshortener.interfaces.http
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 
 fun Application.configureRouting() {
     install(StatusPages) {
+        exception<BadRequestException> { call, cause ->
+            // For validation errors where we want to preserve the custom message as plain text
+            call.respond(HttpStatusCode.BadRequest, cause.message ?: "Invalid request")
+        }
         exception<Throwable> { call, cause ->
             val body = mapOf("code" to "internal_error", "message" to (cause.message ?: "Internal Server Error"))
             call.respond(HttpStatusCode.InternalServerError, body)

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/dto/ShortenRequest.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/dto/ShortenRequest.kt
@@ -1,0 +1,8 @@
+package dev.kotlinbr.utlshortener.interfaces.http.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ShortenRequest(
+    val url: String,
+)

--- a/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/dto/ShortenResponse.kt
+++ b/src/main/kotlin/dev/kotlinbr/utlshortener/interfaces/http/dto/ShortenResponse.kt
@@ -1,0 +1,9 @@
+package dev.kotlinbr.utlshortener.interfaces.http.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ShortenResponse(
+    val slug: String,
+    val path: String,
+)

--- a/src/test/kotlin/dev/kotlinbr/utlshortener/interfaces/http/RoutesIntegrationTest.kt
+++ b/src/test/kotlin/dev/kotlinbr/utlshortener/interfaces/http/RoutesIntegrationTest.kt
@@ -1,0 +1,161 @@
+package dev.kotlinbr.utlshortener.interfaces.http
+
+import dev.kotlinbr.module
+import dev.kotlinbr.utlshortener.domain.Link
+import dev.kotlinbr.utlshortener.infrastructure.db.tables.LinksTable
+import dev.kotlinbr.utlshortener.interfaces.http.dto.LinkResponse
+import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenRequest
+import dev.kotlinbr.utlshortener.interfaces.http.dto.ShortenResponse
+import dev.kotlinbr.utlshortener.testutils.TestClockUtils
+import dev.kotlinbr.utlshortener.testutils.TestDataFactory
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Tag("integration")
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+class RoutesIntegrationTest {
+    companion object {
+        @JvmStatic
+        @Container
+        private val postgres: PostgreSQLContainer<*> =
+            PostgreSQLContainer(
+                "postgres:16-alpine",
+            ).apply { withReuse(true) }
+    }
+
+    @AfterEach
+    fun clearProps() {
+        System.clearProperty("APP_SKIP_DB")
+        System.clearProperty("APP_RUN_MIGRATIONS")
+        System.clearProperty("APP_ENV")
+        System.clearProperty("DB_URL")
+        System.clearProperty("DB_USER")
+        System.clearProperty("DB_PASSWORD")
+    }
+
+    private fun setDbProps() {
+        if (!postgres.isRunning) postgres.start()
+        System.setProperty("APP_ENV", "test")
+        System.setProperty("APP_SKIP_DB", "false")
+        System.setProperty("APP_RUN_MIGRATIONS", "true")
+        System.setProperty("DB_URL", postgres.jdbcUrl)
+        System.setProperty("DB_USER", postgres.username)
+        System.setProperty("DB_PASSWORD", postgres.password)
+    }
+
+    @Test
+    fun `readiness healthy when DB initialized`() =
+        testApplication {
+            setDbProps()
+            application { module() }
+            val res = client.get("/health/ready")
+            assertEquals(HttpStatusCode.OK, res.status)
+            assertEquals("{\"status\":\"ready\"}", res.bodyAsText())
+        }
+
+    @Test
+    fun `api GET links returns empty array on empty DB`() =
+        testApplication {
+            setDbProps()
+            application { module() }
+            val res = client.get("/api/v1/links")
+            assertEquals(HttpStatusCode.OK, res.status)
+            val ct = res.headers[HttpHeaders.ContentType].orEmpty()
+            assertTrue(ct.lowercase().contains("application/json"))
+            assertEquals("[]", res.bodyAsText())
+        }
+
+    @Test
+    fun `api GET links returns data with ISO-8601 dates`() =
+        testApplication {
+            setDbProps()
+            var id1: Long = 0
+            var id2: Long = 0
+            lateinit var link1: Link
+            lateinit var link2: Link
+            application {
+                module()
+                // Ensure a clean state for this test
+                transaction { LinksTable.deleteAll() }
+                // Seed data after migrations
+                val now = TestClockUtils.now()
+                link1 = TestDataFactory.buildLink(createdAt = now, isActive = true, expiresAt = null)
+                link2 =
+                    TestDataFactory.buildLink(createdAt = now, isActive = false, expiresAt = now.plusDays(1))
+                id1 = TestDataFactory.insertLink(link1)
+                id2 = TestDataFactory.insertLink(link2)
+            }
+            val res = client.get("/api/v1/links")
+            assertEquals(HttpStatusCode.OK, res.status)
+            val body = res.bodyAsText()
+            val json = Json { ignoreUnknownKeys = true }
+            val list = json.decodeFromString<List<LinkResponse>>(body)
+            assertEquals(2, list.size)
+            // Since IDs are auto-increment, ensure IDs returned are the inserted ones
+            val ids = list.map { it.id }.toSet()
+            assertTrue(ids.containsAll(listOf(id1, id2)))
+            val byId = list.associateBy { it.id }
+            val r1 = requireNotNull(byId[id1]) { "Response for id=$id1 not found" }
+            val r2 = requireNotNull(byId[id2]) { "Response for id=$id2 not found" }
+            assertEquals(link1.slug, r1.slug)
+            assertEquals(link1.targetUrl, r1.targetUrl)
+            assertEquals(link1.createdAt.toString(), r1.createdAt)
+            assertEquals(true, r1.isActive)
+            assertEquals(null, r1.expiresAt)
+
+            assertEquals(link2.slug, r2.slug)
+            assertEquals(link2.targetUrl, r2.targetUrl)
+            assertEquals(link2.createdAt.toString(), r2.createdAt)
+            assertEquals(false, r2.isActive)
+            assertEquals(link2.expiresAt!!.toString(), r2.expiresAt)
+        }
+
+    @Test
+    fun `api POST shorten creates link and verifies in DB`() =
+        testApplication {
+            setDbProps()
+            application { module() }
+            val request = ShortenRequest(url = "https://example.com/test")
+            val jsonClient = createClient { install(ContentNegotiation) { json() } }
+            val res =
+                jsonClient.post("/api/v1/shorten") {
+                    contentType(ContentType.Application.Json)
+                    setBody(request)
+                }
+            assertEquals(HttpStatusCode.OK, res.status)
+            val body = res.bodyAsText()
+            val json = Json { ignoreUnknownKeys = true }
+            val response = json.decodeFromString<ShortenResponse>(body)
+            assertTrue(response.slug.isNotEmpty())
+            assertEquals("/${response.slug}", response.path)
+
+            // Verify presence in DB
+            val linkInDb = TestDataFactory.findLinkBySlug(response.slug)
+            requireNotNull(linkInDb) { "Link not found in DB" }
+            assertEquals("https://example.com/test", linkInDb.targetUrl)
+            assertEquals(true, linkInDb.isActive)
+        }
+}


### PR DESCRIPTION
## Sumário

Implementa o endpoint `POST /api/v1/shorten` para encurtamento de URLs com validações, testes unitários e de integração. A estrutura de testes foi reorganizada, separando testes unitários e de integração em arquivos dedicados para melhor manutenibilidade.

### Funcionalidades Adicionadas
- **POST /api/v1/shorten**: Cria URLs encurtadas com validações de formato
  - Valida URLs vazias ou compostas apenas por espaços
  - Valida presença de protocolo `http://` ou `https://`
  - Gera slug único usando `SlugGenerator`
  - Persiste link no banco de dados
  - Retorna slug e path gerados

### DTOs Criados
- `ShortenRequest`: Request com campo `url`
- `ShortenResponse`: Response com `slug` e `path`

### Testes Implementados

**Testes Unitários (RoutesUnitTest.kt - 11 testes)**
- Validações de request do endpoint `/shorten`:
  - Rejeita URLs vazias
  - Rejeita URLs com apenas espaços
  - Rejeita URLs sem protocolo http/https
  - Aceita URLs válidas com http
  - Aceita URLs válidas com https

**Testes de Integração (RoutesIntegrationTest.kt - 4 testes)**
- Teste end-to-end do endpoint `/shorten`:
  - Cria link via POST
  - Verifica resposta com status 200
  - Valida presença e dados corretos no banco de dados

### Refatorações
- Separação de `RoutesTest.kt` em arquivos dedicados:
  - `RoutesUnitTest.kt`: Testes sem dependência de DB
  - `RoutesIntegrationTest.kt`: Testes com Testcontainers + PostgreSQL
- Tratamento adequado de erros com `BadRequestException`
- Adição de dependência `ktor-client-content-negotiation` para testes

## Test plan
- [x] Testes unitários passando (11 testes)
- [x] Testes de integração passando (4 testes)
- [x] Validações de URL funcionando corretamente
- [x] Link criado é persistido e recuperável do banco de dados
- [x] Slug único é gerado para cada requisição